### PR TITLE
Added webpack-loader rules in the webpack configuration modules to process images and Javascript

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "css-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.2",
     "http-server": "^0.11.1",
+    "mini-css-extract-plugin": "^2.7.5",
     "style-loader": "^3.2.1",
     "webpack": "^5.51.1",
     "webpack-cli": "^4.8.0",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,29 +1,48 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const WebpackPwaManifest = require('webpack-pwa-manifest');
-const path = require('path');
-const { InjectManifest } = require('workbox-webpack-plugin');
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const WebpackPwaManifest = require("webpack-pwa-manifest");
+const path = require("path");
+const { InjectManifest } = require("workbox-webpack-plugin");
 
 // TODO: Add and configure workbox plugins for a service worker and manifest file.
 // TODO: Add CSS loaders and babel to webpack.
 
 module.exports = () => {
   return {
-    mode: 'development',
+    mode: "development",
     entry: {
-      main: './src/js/index.js',
-      install: './src/js/install.js'
+      main: "./src/js/index.js",
+      install: "./src/js/install.js",
     },
     output: {
-      filename: '[name].bundle.js',
-      path: path.resolve(__dirname, 'dist'),
+      filename: "bundle.js",
+      path: path.resolve(__dirname, "dist"),
     },
     plugins: [
-      
     ],
 
     module: {
       rules: [
-        
+        // to handle images - parses any @import and url() statements in CSS files, resolves them, and injects the resulting CSS into the HTML document.
+        {
+          test: /\.css$/i,
+          use: ["style-loader", "css-loader"],
+        },
+        // to handle images -  emits images to the output directory and their paths will be injected into the bundles
+        {
+          test: /\.(png|svg|jpg|jpeg|gif)$/i,
+          type: "asset/resource",
+        },
+        // tool for compiling modern JavaScript features into a compatible version that can run in older browsers
+        {
+          test: /\.m?js$/,
+          exclude: /(node_modules|bower_components)/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env"],
+            },
+          },
+        },
       ],
     },
   };


### PR DESCRIPTION
- Add a rule to parse and inject CSS code into the HTML document
- Add a rule to emit images to the output directory and inject their paths into the bundles
- Add a rule to transpile modern JavaScript features into a compatible version for older browsers