### PR TITLE
Added a service worker and asset caching functionality

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,12 @@
     "webpack-cli": "^4.8.0",
     "webpack-dev-server": "^4.0.0",
     "webpack-pwa-manifest": "^4.3.0",
+    "workbox-cacheable-response": "^6.5.4",
+    "workbox-expiration": "^6.5.4",
+    "workbox-precaching": "^6.5.4",
+    "workbox-recipes": "^6.5.4",
+    "workbox-routing": "^6.5.4",
+    "workbox-strategies": "^6.5.4",
     "workbox-webpack-plugin": "^6.2.4"
   },
   "dependencies": {

--- a/client/src-sw.js
+++ b/client/src-sw.js
@@ -3,7 +3,7 @@ const { CacheFirst } = require('workbox-strategies');
 const { registerRoute } = require('workbox-routing');
 const { CacheableResponsePlugin } = require('workbox-cacheable-response');
 const { ExpirationPlugin } = require('workbox-expiration');
-const { precacheAndRoute } = require('workbox-precaching/precacheAndRoute');
+import { precacheAndRoute } from "workbox-precaching";
 
 precacheAndRoute(self.__WB_MANIFEST);
 
@@ -26,5 +26,23 @@ warmStrategyCache({
 
 registerRoute(({ request }) => request.mode === 'navigate', pageCache);
 
-// TODO: Implement asset caching
-registerRoute();
+// asset caching (CSS and JS files)
+registerRoute(
+  ({ request }) => {
+    console.log(request);
+    return (
+      // CSS
+      request.destination === "style" ||
+      // JavaScript
+      request.destination === "script"
+    );
+  },
+  new StaleWhileRevalidate({
+    cacheName: "static-resources",
+    plugins: [
+      new CacheableResponsePlugin({
+        statuses: [0, 200],
+      }),
+    ],
+  })
+);

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -4,9 +4,6 @@ const WebpackPwaManifest = require("webpack-pwa-manifest");
 const path = require("path");
 const { InjectManifest } = require("workbox-webpack-plugin");
 
-// TODO: Add and configure workbox plugins for a service worker and manifest file.
-// TODO: Add CSS loaders and babel to webpack.
-
 module.exports = () => {
   return {
     mode: "development",
@@ -32,6 +29,29 @@ module.exports = () => {
       }),
       // Extract CSS code into separate files for improved performance and better cacheability
       new MiniCssExtractPlugin(),
+      // Injects the specified service worker script (our srs-sw.js file) into the generated service worker file
+      new InjectManifest({
+        swSrc: "./src-sw.js",
+        swDest: "service-worker.js",
+      }),
+      new WebpackPwaManifest({
+        // manifest.json:
+        name: "Text Editor PWA",
+        short_name: "Text-Editor",
+        description:
+          "A single-page application text editor that runs in the browser, stores data to an IndexedDB database, and meets the PWA criteria.",
+        background_color: "#7eb4e2", // background color of the PWA's splash screen
+        theme_color: "#7eb4e2",
+        start_url: "./", // URL that the PWA should load when it is launched
+        publicPath: "./", // path to the root of the assets that the PWA uses. This is used to allow the install option in the Chrome address bar.
+        icons: [
+          {
+            src: path.resolve("src/images/logo.png"),
+            sizes: [96, 128, 192, 256, 384, 512],
+            destination: path.join("assets", "icons"),
+          },
+        ],
+      }),
     ],
 
     module: {


### PR DESCRIPTION
- InjectManifest plugin was used to inject the src-sw.js file into the service-worker.js file
- registerRoute method  in srs-sw.js file was used to cache CSS and JS files using the StaleWhileRevalidate caching strategy
- WebpackPwaManifest plugin was used to generate the manifest.json file with various properties such as name, description, background color, theme color, start URL, and icons